### PR TITLE
Fix : Rectify the scoring mechanism

### DIFF
--- a/polygon/Assets/Prefabs/Hexagon.prefab
+++ b/polygon/Assets/Prefabs/Hexagon.prefab
@@ -223,3 +223,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rb: {fileID: 5408253170331927451}
   shrinkSpeed: 4
+  moveByTouch: {fileID: 0}

--- a/polygon/Assets/Scenes/mainGame.unity
+++ b/polygon/Assets/Scenes/mainGame.unity
@@ -151,7 +151,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spawnRate: 0.8
-  hexagonPrefab: {fileID: 5408253170331927447, guid: b09e9ccb0ec5f38438bebebc084e30b6,
+  hexagonPrefab: {fileID: 5408253170331927450, guid: b09e9ccb0ec5f38438bebebc084e30b6,
     type: 3}
   moveByTouch: {fileID: 2127559117}
 --- !u!4 &417606063
@@ -509,8 +509,8 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1632648769}
-        m_MethodName: ToMenu
+      - m_Target: {fileID: 2127559117}
+        m_MethodName: SavePlayer
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/polygon/Assets/Scripts/Hexagon.cs
+++ b/polygon/Assets/Scripts/Hexagon.cs
@@ -5,7 +5,7 @@ public class Hexagon : MonoBehaviour
     public Rigidbody2D rb;
     public float shrinkSpeed = 2f;
 
-
+    public MoveByTouch moveByTouch;
     
     // Start is called before the first frame update
 
@@ -38,7 +38,7 @@ public class Hexagon : MonoBehaviour
             //GameObject.Destroy(gameObject);
             //Debug.Log("After gameObject.Destroy");
 
-
+            moveByTouch.currentScore += 10;
             //Debug.Log("Shrink Speed: " + shrinkSpeed);
 
         }

--- a/polygon/Assets/Scripts/MoveByTouch.cs
+++ b/polygon/Assets/Scripts/MoveByTouch.cs
@@ -11,31 +11,16 @@ public class MoveByTouch : MonoBehaviour
     public int highScore;
     
 
-    
+    void Start()
+    {
+        this.LoadPlayer();
+    }
 
     public void SavePlayer()
     {
-        //highScore = currentScore;
-        //SaveSystem.SavePlayer(this);
-        PlayerData data = SaveSystem.LoadPLayer();
-        if ((data != null) && data.highScore <= currentScore)
-        {
+        if (highScore <= currentScore)
             highScore = currentScore;
-            SaveSystem.SavePlayer(this);
-        }
-        else
-        {
-            if(highScore <= currentScore)
-            {
-                highScore = currentScore;
-                SaveSystem.SavePlayer(this);
-            }
-
-            SaveSystem.SavePlayer(this);
-
-            //Debug.Log("HighScore is greater Bruh!");
-        }
-
+        SaveSystem.SavePlayer(this);
     }
 
     public void LoadPlayer()

--- a/polygon/Assets/Scripts/MoveByTouch.cs
+++ b/polygon/Assets/Scripts/MoveByTouch.cs
@@ -21,6 +21,7 @@ public class MoveByTouch : MonoBehaviour
         if (highScore <= currentScore)
             highScore = currentScore;
         SaveSystem.SavePlayer(this);
+        SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex - 1);
     }
 
     public void LoadPlayer()
@@ -72,14 +73,6 @@ public class MoveByTouch : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
-
-        // not needed I guess..Destroy(gameObject);
-        //
-        
-
-        
-
-        SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex - 1);
         SavePlayer();
     }
 }

--- a/polygon/Assets/Scripts/Spawner.cs
+++ b/polygon/Assets/Scripts/Spawner.cs
@@ -4,7 +4,7 @@ public class Spawner : MonoBehaviour
 {
     public float spawnRate = 1f;
 
-    public GameObject hexagonPrefab;
+    public Hexagon hexagonPrefab;
 
     private float nextTimeToSpawn = 0f;
 
@@ -16,10 +16,10 @@ public class Spawner : MonoBehaviour
     {
         if (Time.time >= nextTimeToSpawn)
         {
-            moveByTouch.currentScore += 10;
             //Debug.Log("Spawnrate: " + spawnRate);
             //Debug.Log("next Time to spawn: " + nextTimeToSpawn);
-            Instantiate(hexagonPrefab, Vector3.zero, Quaternion.identity);
+            Hexagon clone = Instantiate(hexagonPrefab, Vector3.zero, Quaternion.identity);
+            clone.moveByTouch = moveByTouch;
             nextTimeToSpawn = Time.time + 1f / spawnRate;
         }
     }


### PR DESCRIPTION
Contains three commits resolving the problems described in Issue #3 
1. Modify the score updation method, such that the score increases every time a polygon is destroyed and not when it first spawns.
2. Modify the high score recording mechanism, such that after a collision with any polygon, the high score recorded persists through the consecutive game plays.
3. Make the return button in the game window more functional by saving the player data before navigating back to the menu.

Fixes #3 